### PR TITLE
Delete without sort key

### DIFF
--- a/awssdk/src/it/scala/GetOpSpec.scala
+++ b/awssdk/src/it/scala/GetOpSpec.scala
@@ -48,12 +48,11 @@ class GetOpSpec extends ITSpec {
         _ <- resource[IO, cats.Id, TestDataSimple, Unit](
           test,
           t => client.put[TestDataSimple](tableName, t).void,
-          _ => client.delete(tableName, test.id, EmptySortKey)
+          _ => client.delete(tableName, test.id)
         )
-        get = client.get[TestDataSimple, Id, EmptySortKey.type](
+        get = client.get[TestDataSimple, Id](
           tableName,
           test.id,
-          EmptySortKey,
           consistentRead = false
         )
         r <- Resource.liftF(Util.retryOf[IO, Option[TestDataSimple]](
@@ -87,10 +86,9 @@ class GetOpSpec extends ITSpec {
   it should "return None if partition key does not exist, range key is not used" in {
     val tableName = Table("test_partition_key_only")
     val result = Client.resource[IO].use { client =>
-      client.get[TestData, Id, EmptySortKey.type](
+      client.get[TestData, Id](
         tableName,
         Id("doesnt-exists"),
-        EmptySortKey,
         consistentRead = false
       )
     }.unsafeToFuture().futureValue

--- a/awssdk/src/it/scala/GetOpSpec.scala
+++ b/awssdk/src/it/scala/GetOpSpec.scala
@@ -94,4 +94,67 @@ class GetOpSpec extends ITSpec {
     }.unsafeToFuture().futureValue
     result shouldEqual None
   }
+
+  it should "delete an item when using the range key" in forAll {
+    test: TestData =>
+      val tableName = Table("test_primary_keys")
+      val result = for {
+        client <- Client.resource[IO]
+        _ <- resource[IO, cats.Id, TestData, Unit](
+          test,
+          t => client.put[TestData](tableName, t).void,
+          _ => client.delete(tableName, test.id, test.range)
+        )
+        delete = client.delete(tableName, test.id)
+        get = client.get[TestData, Id, Range](
+          tableName,
+          test.id,
+          test.range,
+          consistentRead = false
+        )
+        _ <- Resource.liftF(delete)
+        getResult <- Resource.liftF(Util.retryOf[IO, Option[TestData]](
+          get,
+          1.second,
+          10
+        )(
+          _.isEmpty
+        ))
+      } yield getResult
+
+      result.use[IO, Option[TestData]](
+        r => IO(r)
+      ).unsafeToFuture().futureValue shouldEqual None
+  }
+
+  it should "delete an item when not using the range key" in forAll {
+    test: TestDataSimple =>
+      val tableName = Table("test_partition_key_only")
+      val result = for {
+        client <- Client.resource[IO]
+        _ <- resource[IO, cats.Id, TestDataSimple, Unit](
+          test,
+          t => client.put[TestDataSimple](tableName, t).void,
+          _ => client.delete(tableName, test.id)
+        )
+        delete = client.delete(tableName, test.id)
+        get = client.get[TestDataSimple, Id](
+          tableName,
+          test.id,
+          consistentRead = false
+        )
+        _ <- Resource.liftF(delete)
+        getResult <- Resource.liftF(Util.retryOf[IO, Option[TestDataSimple]](
+          get,
+          1.second,
+          10
+        )(
+          _.isEmpty
+        ))
+      } yield getResult
+
+      result.use[IO, Option[TestDataSimple]](
+        r => IO(r)
+      ).unsafeToFuture().futureValue shouldEqual None
+  }
 }

--- a/awssdk/src/main/scala/Client.scala
+++ b/awssdk/src/main/scala/Client.scala
@@ -68,6 +68,11 @@ trait Client[F[_]] {
     sortKey: S
   ): F[Unit]
 
+  def delete[P: Encoder](
+    table: Table,
+    partitionKey: P
+  ): F[Unit]
+
   def scan[T: Decoder](
     table: Table,
     filter: Expression,

--- a/awssdk/src/main/scala/DefaultClient.scala
+++ b/awssdk/src/main/scala/DefaultClient.scala
@@ -185,6 +185,18 @@ class DefaultClient[F[_]: Concurrent: RaiseThrowable](
     (() => jClient.deleteItem(req)).liftF[F].void
   }
 
+  def delete[P: Encoder](
+    table: Table,
+    partitionKey: P
+  ): F[Unit] = {
+    val req =
+      DeleteItemRequest.builder()
+        .tableName(table.name)
+        .key((Encoder[P].write(partitionKey).m().asScala).asJava)
+        .build()
+    (() => jClient.deleteItem(req)).liftF[F].void
+  }
+
   private case class SegmentPassThrough[U](
     u: U,
     segment: Int

--- a/awssdk/src/main/scala/models.scala
+++ b/awssdk/src/main/scala/models.scala
@@ -9,15 +9,6 @@ case class Table(name: String) extends AnyVal
 
 case class Index(name: String) extends AnyVal
 
-case object EmptySortKey {
-  implicit val emptySortKeyEncoder: Encoder[EmptySortKey.type] =
-    Encoder.instance[EmptySortKey.type] { _ =>
-      AttributeValue.builder().m(
-        Map.empty[String, AttributeValue].asJava
-      ).build()
-    }
-}
-
 sealed trait SortKeyQuery[T]
 object SortKeyQuery {
   case class Empty[T]() extends SortKeyQuery[T]


### PR DESCRIPTION
Only a draft as it may not make much sense :-) 

- The first commit only adds the delete overload without the sort key and deletes that `EmptySortKey` type.
- The second commit adds two tests for the delete operation, but they are a still a WIP