### PR TITLE
Relax some input types to Iterable

### DIFF
--- a/awssdk/src/main/scala/models.scala
+++ b/awssdk/src/main/scala/models.scala
@@ -46,6 +46,9 @@ case class Expression(
 object Expression {
   val empty: Expression =
     Expression("", Map.empty[String, String], Map.empty[String, AttributeValue])
+
+  def apply(expression: String): Expression =
+    Expression(expression, Map.empty, Map.empty)
 }
 
 case class Query[P: Encoder, S: Encoder](


### PR DESCRIPTION
Some batching methods require Seq or Set as inputs. These have been
changed to Iterable to be able to support bigger range of input types.