### PR TITLE
Bump AWS SDK version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val dependencies = Seq(
   "co.fs2" %% "fs2-core" % fs2Version,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
   "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
-  "software.amazon.awssdk" % "dynamodb" % "2.14.15"
+  "software.amazon.awssdk" % "dynamodb" % "2.16.5"
 )
 
 lazy val testDependencies = Seq(


### PR DESCRIPTION
The current AWS SDK version exposes the vulnerability defined [here](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302). 

The latest version of the dynamodb sdk uses a more recent version of jackson core fixing the above