### PR TITLE
Add missing interface for retrieve action

### DIFF
--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - '**.md'
       - 'website/**'
+  pull_request:
+    branches:
+      - 'series/0.x'
+      - 'series/1.x'
 
 jobs:
   build-tests:

--- a/.github/workflows/build-series-0.x.yml
+++ b/.github/workflows/build-series-0.x.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           TAG_CONTEXT: branch
-          RELEASE_BRANCHES: series/0.x,series/1.x
+          RELEASE_BRANCHES: series/0.x
       - name: Import keys
         run: |
           touch /tmp/local.pubring.asc

--- a/.github/workflows/build-series-1.x.yml
+++ b/.github/workflows/build-series-1.x.yml
@@ -63,7 +63,7 @@ jobs:
           WITH_V: true
           TAG_CONTEXT: branch
           PRERELEASE_SUFFIX: RC
-          RELEASE_BRANCHES: series/0.x,series/1.x
+          RELEASE_BRANCHES: series/0.x
       - name: Import keys
         run: |
           touch /tmp/local.pubring.asc

--- a/awssdk/src/main/scala/Client.scala
+++ b/awssdk/src/main/scala/Client.scala
@@ -58,6 +58,15 @@ trait Client[F[_]] {
   /**
     * Retrieve values from a table using a query.
     */
+  def retrieve[P: Encoder, U: Decoder](
+    index: PartitionKeyIndex[P],
+    query: Query[P, Nothing],
+    consistentRead: Boolean
+  ): F[Option[U]]
+
+  /**
+    * Retrieve values from a table using a query.
+    */
   def retrieve[P: Encoder, S: Encoder, U: Decoder](
     index: CompositeKeysIndex[P, S],
     query: Query[P, S],
@@ -334,7 +343,7 @@ trait Client[F[_]] {
     * within a batch.
     */
   def batchPut[T: Encoder](
-    table: Index,
+    table: Index[_],
     maxBatchWait: FiniteDuration,
     backoffStrategy: BackoffStrategy
   ): Pipe[F, T, Unit]
@@ -349,7 +358,7 @@ trait Client[F[_]] {
     * within a batch.
     */
   def batchPut[T: Encoder](
-    table: Index,
+    table: Index[_],
     items: Iterable[T],
     backoffStrategy: BackoffStrategy
   ): F[Unit]
@@ -358,7 +367,7 @@ trait Client[F[_]] {
     * Batch put unique items into a table.
     */
   def batchPutUnordered[T: Encoder](
-    table: Index,
+    table: Index[_],
     items: Set[T],
     parallelism: Int,
     backoffStrategy: BackoffStrategy

--- a/awssdk/src/main/scala/DefaultClient.scala
+++ b/awssdk/src/main/scala/DefaultClient.scala
@@ -38,6 +38,13 @@ class DefaultClient[F[_]: Concurrent: Timer: RaiseThrowable](
   ): F[Option[U]] =
     getOp[F, P, S, U](table, partitionKey, sortKey, consistentRead)(jClient)
 
+  def retrieve[P: Encoder, U: Decoder](
+    index: PartitionKeyIndex[P],
+    query: Query[P, Nothing],
+    consistentRead: Boolean
+  ): F[Option[U]] =
+    retrieveOp[F, P, U](index, query, consistentRead)(jClient)
+
   def retrieve[P: Encoder, S: Encoder, U: Decoder](
     index: CompositeKeysIndex[P, S],
     query: Query[P, S],
@@ -311,14 +318,14 @@ class DefaultClient[F[_]: Concurrent: Timer: RaiseThrowable](
     )
 
   def batchPut[T: Encoder](
-    table: Index,
+    table: Index[_],
     maxBatchWait: FiniteDuration,
     backoffStrategy: BackoffStrategy
   ): Pipe[F, T, Unit] =
     batchPutInorderedOp[F, T](table, maxBatchWait, backoffStrategy)(jClient)
 
   def batchPut[T: Encoder](
-    table: Index,
+    table: Index[_],
     items: Iterable[T],
     backoffStrategy: BackoffStrategy
   ): F[Unit] = {
@@ -331,7 +338,7 @@ class DefaultClient[F[_]: Concurrent: Timer: RaiseThrowable](
   }
 
   def batchPutUnordered[T: Encoder](
-    table: Index,
+    table: Index[_],
     items: Set[T],
     parallelism: Int,
     backoffStrategy: BackoffStrategy

--- a/awssdk/src/main/scala/api/BatchWriteOps.scala
+++ b/awssdk/src/main/scala/api/BatchWriteOps.scala
@@ -26,7 +26,7 @@ trait SharedBatchWriteOps extends DedupOps {
   val MaxBatchWriteSize = 25
 
   def batchPutInorderedOp[F[_]: Timer: Concurrent, I: Encoder](
-    table: Index,
+    table: Index[_],
     maxBatchWait: FiniteDuration,
     backoffStrategy: BackoffStrategy
   )(jClient: DynamoDbAsyncClient): Pipe[F, I, Unit] = { in: Stream[F, I] =>
@@ -93,7 +93,7 @@ trait SharedBatchWriteOps extends DedupOps {
     F[_]: Timer: Concurrent,
     I: Encoder
   ](
-    table: Index,
+    table: Index[_],
     maxBatchWait: FiniteDuration
   ): Pipe[F, I, BatchWriteItemRequest] =
     _.groupWithin(MaxBatchWriteSize, maxBatchWait).evalMap { chunk =>


### PR DESCRIPTION
When refactoring `Table` in version 0.18 to separated types such as `CompositeKeysTable` and `PartitionKeyTable`, the `retrieve` method was missing to get an item from `PartitionKeyTable` but using `Query` so that filtering is done on server side. This PR adds the missing method.