### PR TITLE
Attempt to fix flaky tests

### DIFF
--- a/awssdk/src/it/scala/api/hi/CompositeIndexSpec.scala
+++ b/awssdk/src/it/scala/api/hi/CompositeIndexSpec.scala
@@ -48,9 +48,13 @@ class CompositeIndexSpec extends ITSpec {
 
   it should "retrieve multiple items for the same partition key" in {
     val partitionKey = Id("foo")
-    val data = List.fill(200)(sample[TestData]).map { item =>
-      item.copy(id = partitionKey)
-    }
+    val data =
+      List.fill(200)(sample[Range]).distinct.map { range =>
+        sample[TestData].copy(
+          id = partitionKey,
+          range = range
+        )
+      }
     val result = compositeTable[IO].use { table =>
       table.batchPut[TestData](
         1.minute,
@@ -102,9 +106,13 @@ class CompositeIndexSpec extends ITSpec {
 
   it should "retrieve multiple items for the same partition key" in {
     val partitionKey = "foo"
-    val data = List.fill(200)(sample[TestData]).map { item =>
-      item.copy(str = partitionKey)
-    }
+    val data =
+      List.fill(200)(sample[Range]).distinct.map { range =>
+        sample[TestData].copy(
+          str = partitionKey,
+          range = range
+        )
+      }
     val result = secondaryCompositeIndex[IO].use {
       case (table, index) =>
         table.batchPut[TestData](

--- a/awssdk/src/it/scala/api/hi/CompositeTableBatchSpec.scala
+++ b/awssdk/src/it/scala/api/hi/CompositeTableBatchSpec.scala
@@ -14,7 +14,9 @@ class CompositeTableBatchSpec extends ITSpec {
   val backOff = Client.BackoffStrategy.default
 
   it should "round trip batch put and batch get items" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Range]).distinct.map { range =>
+      sample[TestData].copy(range = range)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(i => (i.id, i.range))).covary[IO]
 
@@ -22,7 +24,9 @@ class CompositeTableBatchSpec extends ITSpec {
   }
 
   it should "deduplicate batch get items (within the same batch)" in {
-    val samples = List.fill(50)(sample[TestData])
+    val samples = List.fill(50)(sample[Range]).distinct.map { range =>
+      sample[TestData].copy(range = range)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys =
       Stream.emits(samples.map(i => (i.id, i.range)) ++ samples.map(i =>
@@ -42,7 +46,9 @@ class CompositeTableBatchSpec extends ITSpec {
   }
 
   it should "batch put items unordered" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Range]).map { range =>
+      sample[TestData].copy(range = range)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(i => (i.id, i.range))).covary[IO]
 
@@ -50,7 +56,9 @@ class CompositeTableBatchSpec extends ITSpec {
   }
 
   it should "batch delete items" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Range]).map { range =>
+      sample[TestData].copy(range = range)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(i => (i.id, i.range))).covary[IO]
 

--- a/awssdk/src/it/scala/api/hi/SimpleTableBatchSpec.scala
+++ b/awssdk/src/it/scala/api/hi/SimpleTableBatchSpec.scala
@@ -14,7 +14,9 @@ class SimpleTableBatchSpec extends ITSpec {
   val backOff = Client.BackoffStrategy.default
 
   it should "round trip batch put and batch get items" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Id]).map { id =>
+      sample[TestData].copy(id = id)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(_.id)).covary[IO]
 
@@ -22,7 +24,9 @@ class SimpleTableBatchSpec extends ITSpec {
   }
 
   it should "deduplicate batch get items (within the same batch)" in {
-    val samples = List.fill(50)(sample[TestData])
+    val samples = List.fill(50)(sample[Id]).map { id =>
+      sample[TestData].copy(id = id)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys =
       Stream.emits(samples.map(_.id) ++ samples.map(_.id)).covary[IO]
@@ -41,7 +45,9 @@ class SimpleTableBatchSpec extends ITSpec {
   }
 
   it should "batch put items unordered" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Id]).map { id =>
+      sample[TestData].copy(id = id)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(_.id)).covary[IO]
 
@@ -49,7 +55,9 @@ class SimpleTableBatchSpec extends ITSpec {
   }
 
   it should "batch delete items" in {
-    val samples = List.fill(200)(sample[TestData])
+    val samples = List.fill(200)(sample[Id]).map { id =>
+      sample[TestData].copy(id = id)
+    }
     val input = Stream.emits(samples).covary[IO]
     val keys = Stream.emits(samples.map(_.id)).covary[IO]
 


### PR DESCRIPTION
Some tests generate random TestData with duplicated partition/sort key(s) where it is unique data that need to be generated.