### PR TITLE
make str field in TestData non-empty

### DIFF
--- a/awssdk/src/test/scala/models.scala
+++ b/awssdk/src/test/scala/models.scala
@@ -58,10 +58,10 @@ object TestData {
     for {
       id <- implicitly[Gen[Id]]
       range <- implicitly[Gen[Range]]
-      str <- Gen.asciiPrintableStr
+      str <- Gen.nonEmptyListOf(Gen.asciiPrintableChar)
       int <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
       bool <- Gen.oneOf(Seq(true, false))
-    } yield TestData(id, range, str, int, bool)
+    } yield TestData(id, range, str.mkString, int, bool)
 
   implicit val arbTestData: Arbitrary[TestData] = Arbitrary(genTestData)
 }


### PR DESCRIPTION
str field in TestData could be empty string, this is fine normally.
However, some tests which use this field as secondary index will require
non-empty string as key.
