### PR TITLE
Fix documentation of dynosaur conversion

### DIFF
--- a/website/content/docs/codec/dynosaur/index.md
+++ b/website/content/docs/codec/dynosaur/index.md
@@ -19,8 +19,8 @@ feature, hence, it is subjected to change.
 
 ```scala
 import meteor.dynosaur.formats.conversions._
-import meteor.Codec
+import meteor.codec.Codec
 
 val bookSchema: Schema[Book] = ...
-val bookCodec: Codec[Book] = implicitly[Codec[Book]]
+val bookCodec: Codec[Book] = bookSchema
 ```


### PR DESCRIPTION
Given the current implementation of `schemaToCodec` as an implicit conversion, you cannot summon a `Codec` from a `Schema` (even if you fix the example to make the schema value implicit), so this example demonstrating conversion is what works (in normal use, presumably you would make it `implicit val bookCodec: Codec[Book] = bookSchema`. I think this PR should be merged and the site updated to work with the current implementation.

Separately, I do wonder if schemaToCodec should _not_ be an implicit conversion, but instead should take the `schema` argument implicitly: `implicit def schemaToCodec[A](implicit schema: Schema[A]): Codec[A] = {...`, then something like the original version of this doc would work if you did `implicit val bookSchema...`