### PR TITLE
Exposes lastEvaluatedKey in the scan client function

### DIFF
--- a/awssdk/src/main/scala/Client.scala
+++ b/awssdk/src/main/scala/Client.scala
@@ -170,6 +170,17 @@ trait Client[F[_]] {
     parallelism: Int
   ): fs2.Stream[F, U]
 
+  /** Scan a table. Allows to pass an initialKey from where to start
+   * scanning.
+   * Returns the stream with the lastKey. Useful to use for checkpointing.
+    */
+  def scan[U: Decoder](
+    tableName: String,
+    consistentRead: Boolean,
+    parallelism: Int,
+    initialKey: Option[java.util.Map[String, AttributeValue]] = None
+  ): fs2.Stream[F, (Option[java.util.Map[String, AttributeValue]], U)]
+
   /** Update an item by partition key P given an update expression.
     * A Codec of U is required to deserialize return value.
     */

--- a/awssdk/src/main/scala/api/ScanOps.scala
+++ b/awssdk/src/main/scala/api/ScanOps.scala
@@ -91,8 +91,10 @@ private[meteor] trait ScanOps {
   private[meteor] def scanOp[F[_]: Async: RaiseThrowable, T: Decoder](
     tableName: String,
     consistentRead: Boolean,
-    parallelism: Int
-  )(jClient: DynamoDbAsyncClient): fs2.Stream[F, T] = {
+    parallelism: Int,
+    initialKey: Option[java.util.Map[String, AttributeValue]] = None
+  )(jClient: DynamoDbAsyncClient)
+    : fs2.Stream[F, (Option[java.util.Map[String, AttributeValue]], T)] = {
 
     def requestBuilder(
       startKey: Option[java.util.Map[String, AttributeValue]]
@@ -108,7 +110,7 @@ private[meteor] trait ScanOps {
 
     lazy val initRequests =
       Stream.range(0, parallelism).map { index =>
-        val builder = requestBuilder(None)
+        val builder = requestBuilder(initialKey)
         SegmentPassThrough(builder.segment(index).build(), index)
       }
 
@@ -142,7 +144,7 @@ private[meteor] trait ScanOps {
       resp <- sendPipe(initRequests)
       attrs <- fs2.Stream.emits(resp.u.items().asScala.toList)
       t <- fs2.Stream.fromEither(attrs.asAttributeValue.as[T])
-    } yield t
+    } yield (Some(resp.u.lastEvaluatedKey()), t)
   }
 
   private case class SegmentPassThrough[U](


### PR DESCRIPTION
Overloads the `scan` client function with an extra parameter:

`lastEvaluatedKey` 

It also returns a stream with a tuple of the `lastEvaluatedKey` and the rows.

This is useful to use when you want to checkpoint and in case of a failure while scanning restart on the `lastEvaluatedKey`